### PR TITLE
Add Google DNS-over-HTTPS proxy for a full working corporate MITM-MIT…

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,37 @@ others above, `CONFIG_DISABLE` prevents overwriting templated files.
     if you need more flexibility.
  * `PROXYCHAIN_DNS`
    Default none. When set to `yes`, turns on the `proxy_dns` option for Proxychains.
-  
+
+# DNS-over-HTTPS via CoreDNS
+In some corporate environments, its not possible to get reliable DNS outbound
+service and `proxychains-ng`'s DNS support won't be able to provide for Squid4
+to actually work. To address this, configuration is included to setup and use
+CoreDNS as a routing proxy.
+
+The idea of the DNS-over-HTTPS client is that it will use your local proxy and
+network access to provide DNS service to Squid4.
+
+* `DNS_OVER_HTTPS`
+  Default `no`. If `yes` then enables and starts the DNS_OVER_HTTPS service.
+* `DNS_OVER_HTTPS_LISTEN_ADDR`
+  Default `127.0.0.153:53`. Squid doesn't support changing the port, so keep
+  this in mind.
+* `DNS_OVER_HTTPS_SERVER`
+  Default `https://dns.google.com/resolve`. AFAIK there's no other options for
+  this at the moment.
+* `DNS_OVER_HTTPS_NO_PROXY`
+  Default ``. List of DNS suffixes to *not* ever proxy via DNS_OVER_HTTPS.
+* `DNS_OVER_HTTPS_PREFIX_SERVER`
+  Default ``. Normal DNS server to try resolving first against.
+* `DNS_OVER_HTTPS_SUFFIX_SERVER`
+  Default ``. Normal DNS server to try resolving last against.
+
+Since the DNS-over-HTTPS daemon is a separate Go binary, you may also need to
+specify your internal proxy as an upstream to allow it to contact the HTTPS
+DNS server - do this by passing the standard `http_proxy` and `https_proxy`
+parameters. Most likely these will be the same as your `PROXYCHAIN_PROXYx`
+directives (and probably only the 1).
+
 # Example Usage
 The following command line will get you up and running quickly. It presumes
 you've generated a suitable CA certificate and are intending to use the proxy

--- a/docker-squid/Dockerfile
+++ b/docker-squid/Dockerfile
@@ -2,6 +2,13 @@ ARG DOCKER_PREFIX=
 
 FROM ${DOCKER_PREFIX}ubuntu:artful
 
+ARG TRUST_CERT=
+
+RUN if [ ! -z "$TRUST_CERT" ]; then \
+        echo "$TRUST_CERT" > /usr/local/share/ca-certificates/build-trust.crt ; \
+        update-ca-certificates ; \
+    fi
+
 # Normalize apt sources
 RUN cat /etc/apt/sources.list | grep -v '^#' | sed /^$/d | sort | uniq > sources.tmp.1 && \
     cat /etc/apt/sources.list | sed s/deb\ /deb-src\ /g | grep -v '^#' | sed /^$/d | sort | uniq > sources.tmp.2 && \
@@ -81,11 +88,33 @@ RUN git clone https://github.com/rofl0r/proxychains-ng.git /src/proxychains-ng &
     ./configure --prefix=/usr --sysconfdir=/etc && \
     make -j$CONCURRENCY && make install
 
+ARG URL_DOH=https://github.com/wrouesnel/dns-over-https-proxy/releases/download/v0.0.2/dns-over-https-proxy_v0.0.2_linux-amd64.tar.gz
+
+RUN wget -O /tmp/doh.tgz \
+    $URL_DOH && \
+    tar -xvvf /tmp/doh.tgz --strip-components=1 -C /usr/local/bin/ && \
+    chmod +x /usr/local/bin/dns-over-https-proxy
+
 COPY squid.conf.p2 /squid.conf.p2
 COPY squid.bsh /squid.bsh
 
 # Configuration environment
-ENV HTTP_PORT=3128 ICP_PORT= HTCP_PORT= MITM_PROXY= MITM_CERT= MITM_KEY=  VISIBLE_HOSTNAME=docker-squid4 MAX_CACHE_SIZE=40000 MAX_OBJECT_SIZE="1536 MB" MEM_CACHE_SIZE="128 MB"
+ENV HTTP_PORT=3128 \
+    ICP_PORT= \
+    HTCP_PORT= \
+    MITM_PROXY= \
+    MITM_CERT= \
+    MITM_KEY= \
+    VISIBLE_HOSTNAME=docker-squid4 \
+    MAX_CACHE_SIZE=40000 \
+    MAX_OBJECT_SIZE="1536 MB" \
+    MEM_CACHE_SIZE="128 MB" \
+    DNS_OVER_HTTPS_LISTEN_ADDR="127.0.0.153:53" \
+    DNS_OVER_HTTPS_SERVER="https://dns.google.com/resolve" \
+    DNS_OVER_HTTPS_NO_FALLTHROUGH="" \
+    DNS_OVER_HTTPS_FALLTHROUGH_STATUSES=NXDOMAIN \
+    DNS_OVER_HTTPS_PREFIX_SERVER= \
+    DNS_OVER_HTTPS_SUFFIX_SERVER=
 
 EXPOSE 3128
 

--- a/docker-squid/squid.bsh
+++ b/docker-squid/squid.bsh
@@ -68,6 +68,20 @@ else
     echo "/etc/squid4/squid.conf: CONFIGURATION TEMPLATING IS DISABLED."
 fi
 
+if [ "$DNS_OVER_HTTPS" = "yes" ]; then
+    echo "Starting DNS-over-HTTPS proxy..."
+    # TODO: find a way to tie this to the proxychains config
+    dns-over-https-proxy -default "$DNS_OVER_HTTPS_SERVER" \
+        -address "$DNS_OVER_HTTPS_LISTEN_ADDR" \
+        -primary-dns "$DNS_OVER_HTTPS_PREFIX_SERVER" \
+        -fallback-dns "$DNS_OVER_HTTPS_SUFFIX_SERVER" \
+        -no-fallthrough "$(echo $DNS_OVER_HTTPS_NO_FALLTHROUGH | tr -s ' ' ',')" \
+        -fallthrough-statues "$DNS_OVER_HTTPS_FALLTHROUGH_STATUSES"
+        &
+    echo "Adding dns_nameservers line to squid.conf..."
+    echo "dns_nameservers $(echo $DNS_OVER_HTTPS_LISTEN_ADDR | cut -d':' -f1)" >> /etc/squid4/squid.conf
+fi
+
 if [ ! -e /etc/squid4/squid.conf ]; then
     echo "ERROR: /etc/squid4/squid.conf does not exist. Squid will not work."
     exit 1
@@ -106,16 +120,16 @@ if [ "$PROXYCHAIN" = "yes" ]; then
         exit 1
     fi 
     # Start squid with proxychains
-    proxychains4 squid -N &
+    proxychains4 -f /etc/proxychains.conf squid -N 2>&1 &
     PID=$!
 else
     # Start squid normally
-    squid -N &
+    squid -N 2>&1 &
     PID=$!
 fi
 
 # This construct allows signals to kill the container successfully.
-trap "kill -TERM $PID" INT TERM
+trap "kill -TERM $(jobs -p)" INT TERM
 wait $PID
 wait $PID
 exit $?


### PR DESCRIPTION
…M-host

Add the necessary extra daemons to allow running this image behind a corporate
MITM webserver with a local MITM enabled for local caching even in the absence
of proper internal DNS service.