### PR TITLE
Update to Squid 4.13 and Ubuntu 20.04

### DIFF
--- a/docker-squid/Dockerfile
+++ b/docker-squid/Dockerfile
@@ -1,6 +1,6 @@
 ARG DOCKER_PREFIX=
 
-FROM ${DOCKER_PREFIX}ubuntu:artful
+FROM ${DOCKER_PREFIX}ubuntu:20.04
 
 ARG TRUST_CERT=
 
@@ -19,7 +19,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get build-dep -y squid && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y wget tar xz-utils libssl-dev nano
 
-ARG SQUID_VERSION=4.0.25
+ARG SQUID_VERSION=4.13
 
 # TODO: verify the squid download with the signing key
 RUN mkdir /src \
@@ -44,7 +44,7 @@ RUN cd /src/squid && \
 		--enable-underscores \
 		--enable-icap-client \
 		--enable-follow-x-forwarded-for \
-		--enable-auth-basic="DB,fake,getpwnam,LDAP,NCSA,NIS,PAM,POP3,RADIUS,SASL,SMB" \
+		--enable-auth-basic="DB,fake,getpwnam,LDAP,NCSA,PAM,POP3,RADIUS,SASL,SMB" \
 		--enable-auth-digest="file,LDAP" \
 		--enable-auth-negotiate="kerberos,wrapper" \
 		--enable-auth-ntlm="fake" \
@@ -67,7 +67,7 @@ RUN cd /src/squid && \
         --disable-arch-native \
         --disable-ipv6
 		
-ARG CONCURRENCY=1
+ARG CONCURRENCY=4
 
 RUN cd /src/squid && \
     make -j$CONCURRENCY && \

--- a/docker-squid/squid.bsh
+++ b/docker-squid/squid.bsh
@@ -123,7 +123,7 @@ if [ "$PROXYCHAIN" = "yes" ]; then
     PID=$!
 else
     # Start squid normally
-    squid -N 2>&1 &
+    squid --foreground 2>&1 &
     PID=$!
 fi
 

--- a/run_squid.sh
+++ b/run_squid.sh
@@ -1,0 +1,19 @@
+# to generate the SSL certs:
+# openssl req -new -newkey rsa:2048 -sha256 -days 3650 -nodes -x509 -extensions v3_ca \
+#    -keyout ssl_bump.pem -out ssl_bump.crt
+
+# to build the container
+# docker build . -t ubuntu-squid
+
+mkdir $(pwd)/squid_cache
+
+docker run -it -p 3128:3128 --rm \
+    -v $(pwd)/squid_cache:/var/cache/squid4 \
+    -v $(pwd)/ssl_bump.pem:/ssl_bump.pem:ro -v $(pwd)/ssl_bump.crt:/ssl_bump.crt:ro \
+    -e MITM_CERT=/ssl_bump.crt \
+    -e MITM_KEY=/ssl_bump.pem \
+    -e MITM_PROXY=yes \
+    -e EXTRA_CONFIG_0="" \
+    ubuntu-squid
+
+


### PR DESCRIPTION
I have modified the Dockerfile to use Ubuntu 20.04 and to build Squid version 4.13 (latest to date).

I have had to remove the `NIS` auth plugin, as it was not anymore compatible. Apart from that, everything works correctly 👍🏼

Finally, I have added an example bash script I use to run the proxy, in which I also included the commands needed to generate the SSL certificates used for MITM interception (also known as `ssl bumping` in Squid terms 😉)